### PR TITLE
Fix Mumps@exist

### DIFF
--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -264,6 +264,14 @@ class Mumps(Package):
             shutil.move('pymumps.py', pypath)
             shutil.copy('Makefile.inc', pypath)
 
+    # to use the existing version available in the environment: MUMPS_DIR environment variable must be set
+    @when('@exist')
+    def install(self, spec, prefix):
+        os.chdir(self.get_env_dir(self.name.upper()+'_DIR'))
+        #os.symlink("bin", prefix.bin)
+        os.symlink("include", prefix.include)
+        os.symlink("lib", prefix.lib)
+
     def setup_dependent_package(self, module, dep_spec):
         """Dependencies of this package will get the link for Mumps."""
         spec = self.spec


### PR DESCRIPTION
The `@exist` version was listed, but no custom install was proposed.
I copied the custom `@exist` install from Pastix.