### PR TITLE
a new version of SimGrid is out

### DIFF
--- a/var/spack/repos/builtin/packages/simgrid/package.py
+++ b/var/spack/repos/builtin/packages/simgrid/package.py
@@ -4,18 +4,18 @@ import spack
 
 class Simgrid(Package):
     """To study the behavior of large-scale distributed systems such as Grids, Clouds, HPC or P2P systems."""
-    homepage = "http://simgrid.gforge.inria.fr/index.html"
-    url      = "http://gforge.inria.fr/frs/download.php/file/35215/SimGrid-3.12.tar.gz"
+    homepage = "http://simgrid.org/"
+    url      = "https://gforge.inria.fr/frs/download.php/file/37294/SimGrid-3.18.tar.gz"
 
 
+    version('3.18', 'a3f457f70eb9ef095c275672b21247f4',
+            url='https://gforge.inria.fr/frs/download.php/file/37294/SimGrid-3.18.tar.gz')
     version('3.13', '8ace1684972a01429d5f1c5db8966709',
             url='http://gforge.inria.fr/frs/download.php/file/35817/SimGrid-3.13.tar.gz')
     version('3.12', 'd73faaf81d7a9eb0d309cfd72532c5f1',
             url='http://gforge.inria.fr/frs/download.php/file/35215/SimGrid-3.12.tar.gz')
     version('3.11', '358ed81042bd283348604eb1beb80224',
             url='http://gforge.inria.fr/frs/download.php/file/33683/SimGrid-3.11.tar.gz')
-    version('3.10', 'a345ad07e37539d54390f817b7271de7',
-            url='http://gforge.inria.fr/frs/download.php/file/33124/SimGrid-3.10.tar.gz')
     version('master', git='https://scm.gforge.inria.fr/anonscm/git/simgrid/simgrid.git')
     version('starpumpi', git='https://scm.gforge.inria.fr/anonscm/git/simgrid/simgrid.git', branch='starpumpi')
 


### PR DESCRIPTION
Just add a new version of the SimGrid software (and remove a very old one).

I hope that this change is OK as I have no way to ensure that this is the case. I can just tell you that the URL and the md5sum are right.